### PR TITLE
Add cellpose docs

### DIFF
--- a/morphodynamics/analysis_par.py
+++ b/morphodynamics/analysis_par.py
@@ -6,7 +6,7 @@ import numpy as np
 from scipy.ndimage import center_of_mass
 from scipy.interpolate import splev
 import skimage.io
-from napari_convpaint.conv_paint_utils import Classifier
+from napari_convpaint.conv_paint_classifier import Classifier
 
 from .segmentation import (
     segment_cellpose,

--- a/mydocs/Installation.ipynb
+++ b/mydocs/Installation.ipynb
@@ -37,7 +37,7 @@
     "\n",
     "If you wish to enable Cellpose-based feature extraction, you can install the necessary dependencies with:\n",
     "\n",
-    "    pip install napari-convpaint[cellpose]"
+    "    pip install 'napari-convpaint[cellpose]'\n"
    ]
   },
   {

--- a/mydocs/Installation.ipynb
+++ b/mydocs/Installation.ipynb
@@ -31,10 +31,13 @@
     "\n",
     "    pip install git+https://github.com/guiwitz/MorphoDynamics.git@master#egg=morphodynamics\n",
     "\n",
-    "To update the softate you can simply use:\n",
+    "To update the software you can simply use:\n",
     "\n",
+    "    pip install --upgrade morphodynamics\n",
     "\n",
-    "    pip install --upgrade morphodynamics"
+    "If you wish to enable Cellpose-based feature extraction, you can install the necessary dependencies with:\n",
+    "\n",
+    "    pip install napari-convpaint[cellpose]"
    ]
   },
   {


### PR DESCRIPTION
- Added the command `pip install 'napari-convpaint[cellpose]'` to the installation section.
- Aim for compatibility by wrapping the package name in talk marks to prevent shell interpretation issues.
- Cellpose installation is required for the `Run_analysis` notebook to function properly.